### PR TITLE
Add markdown formatting with vendored prettier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+.ipynb_checkpoints/
+*.egg-info
+dist/
+envs/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include prenotebook *.ipynb
+recursive-include prenotebook *.ipynb *.js

--- a/prenotebook/prenotebook.ipynb
+++ b/prenotebook/prenotebook.ipynb
@@ -24,6 +24,8 @@
     "import itertools\n",
     "import json\n",
     "import pathlib\n",
+    "import shutil\n",
+    "import subprocess\n",
     "import sys\n",
     "import textwrap\n",
     "import typing\n",
@@ -32,6 +34,15 @@
     "import click\n",
     "import nbformat\n",
     "import ujson"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NODE = shutil.which(\"node\") or shutil.which(\"nodejs\")"
    ]
   },
   {
@@ -178,6 +189,29 @@
     "                        raise OutOfOrder(self.filename)\n",
     "                    min = cell[\"execution_count\"]\n",
     "\n",
+    "    def prettier(self, cell):\n",
+    "        if NODE:\n",
+    "            if cell[\"cell_type\"] == \"markdown\":\n",
+    "                prettier = subprocess.Popen(\n",
+    "                    [\n",
+    "                        NODE,\n",
+    "                        pathlib.Path(__file__).parent\n",
+    "                        / \"prettier-legacy-1.19.1.js\",\n",
+    "                        \"--stdin-filepath\",\n",
+    "                        \"foo.md\",\n",
+    "                        \"--print-width\",\n",
+    "                        str(self.line_width),\n",
+    "                    ],\n",
+    "                    stdin=subprocess.PIPE,\n",
+    "                    stdout=subprocess.PIPE,\n",
+    "                )\n",
+    "                out, err = prettier.communicate(\n",
+    "                    \"\".join(cell[\"source\"]).rstrip().encode(\"utf-8\")\n",
+    "                )\n",
+    "                cell[\"source\"] = out.decode(\"utf-8\").rstrip().splitlines(True)\n",
+    "\n",
+    "        return cell\n",
+    "\n",
     "    def fix(self, *args):\n",
     "        changed = False\n",
     "        for i, cell in enumerate(self.node.cells):\n",
@@ -188,6 +222,7 @@
     "                self.normalize_execution,\n",
     "                self.blacken,\n",
     "                self.isort,\n",
+    "                self.prettier,\n",
     "            ):\n",
     "                cell = callable(cell)\n",
     "            if object != cell:\n",
@@ -222,7 +257,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/readme.ipynb
+++ b/readme.ipynb
@@ -6,16 +6,17 @@
    "source": [
     "[pre-commit hooks](https://pre-commit.com/) for notebooks:\n",
     "\n",
-    "* Strip outputs\n",
-    "* Ignore `execution_count`\n",
-    "* Blacken & Isort code cells\n"
+    "- Strip outputs\n",
+    "- Ignore `execution_count`\n",
+    "- `black`en & `isort` python code cells\n",
+    "- `prettier` markdown cells"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Add the `prenotebook` pre \n"
+    "Add the `prenotebook` pre"
    ]
   },
   {
@@ -28,7 +29,7 @@
     "    \"file\",\n",
     "    \".pre-commit-config.yaml\",\n",
     "    \"repos:\\n- repo: https://github.com/ambv/black\\n  rev: 19.10b0\\n  hooks:\\n  - id: black\\n- repo: https://github.com/deathbeds/prenotebook\\n  rev: e8b3b91d9dc195a67f42177a9f3298f9749ea43a\\n  hooks:\\n  - id: prenotebook\",\n",
-    ")\n"
+    ")"
    ]
   },
   {
@@ -39,7 +40,7 @@
    "source": [
     "get_ipython().system(\n",
     "    \"jupyter nbconvert --to markdown --TemplateExporter.exclude_output=True readme.ipynb\"\n",
-    ")\n"
+    ")"
    ]
   }
  ],
@@ -59,7 +60,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- [x] adds vendored `prettier` compiled with all dependencies to a single file, a la `yarn`
  - couldn't get it to survive any of the mimimizers
  - but worth it vs an `npm` install
- [x] adds `.gitignore`
- [x] adds `prettier` to available steps (if `node` or `nodejs` is found)
- [x] applies `prettier` to this repo's notebooks